### PR TITLE
Minor: Correct index.html title to match sample directory

### DIFF
--- a/samples/ajax/index.html
+++ b/samples/ajax/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Socket Example</title>
+  <title>Ajax Example</title>
   <script src="index.js"></script>
 </head>
 


### PR DESCRIPTION
Just changed the `index.html` title so it corresponds to the `samples/ajax/` directory