### PR TITLE
Allow WSS

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -14,7 +14,7 @@ function startServer({
       settings,
       dataPath,
     });
-  } else if (settings.protocol === 'ws') {
+  } else if (settings.protocol === 'ws' || settings.protocol === 'wss') {
     startSocketServer({
       logger,
       syncHandler: syncHandler.socketHandler,

--- a/lib/server/socket/server.js
+++ b/lib/server/socket/server.js
@@ -62,7 +62,7 @@ function startSocketServer({
     // { secure: true } needed by nodejs-websocket
     const wssOptions = Object.assign({ secure: true }, wssSettings, readCertificates(dataPath, wssSettings));
 
-    ws.createServer(connect, wssOptions).listen(settings.port, () => {
+    ws.createServer(wssOptions, connect).listen(settings.port, () => {
       printInterfaces(logger, settings.protocol, settings.port);
     });
   }


### PR DESCRIPTION
Hey @nponiros,

Thanks heaps for these (this and sync-client) projects. I'm working on a personal (learning) PWA project, and decided on Dexie over PouchDB. Both these projects have helped me bootstrap extremely quick.

I wasn't able to get WSS to work however (everything else worked flawlessly), so decided to look into it a bit.

I was getting Protocol not supported error when using WSS. One change adds an or condition that will match wss.

Second change, callback and options were ordered incorrectly (https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener), so were not picked up.

Now have WSS working correctly, using https://github.com/dfahlander/Dexie.js/blob/master/samples/remote-sync/websocket/WebSocketSyncProtocol.js from the client! :)

Thanks again, mate!

Second 